### PR TITLE
Added missing keywords in grammer

### DIFF
--- a/grammars/d.cson
+++ b/grammars/d.cson
@@ -155,7 +155,7 @@
     'name': 'storage.modifier.access-control.d'
   }
   {
-    'match': '\\b(shared|auto|static|override|final|const|abstract|volatile|synchronized|lazy)\\b'
+    'match': '\\b(shared|auto|static|override|final|const|abstract|volatile|synchronized|lazy|immutable)\\b'
     'name': 'storage.modifier.d'
   }
   {
@@ -201,6 +201,18 @@
   {
     'match': '\\b(import)\\b'
     'name': 'keyword.control.import.d'
+  }
+  {
+    'match': '\\b(pure|nothrow|ref)\\b'
+    'name': 'keyword.attribute.d'
+  }
+  {
+    'match': '\\s@(property|nogc|safe|system|trusted)\\b'
+    'name': 'keyword.attribute.d'
+  }
+  {
+    'match': '\\b(assert)\\b'
+    'name': 'keyword.assert.d'
   }
   {
     'captures':
@@ -369,7 +381,7 @@
       }
     ]
   'storage-type-d':
-    'match': '\\b(void|byte|short|char|dchar|wchar|int|long|string|float|double|bool|([a-z]\\w+\\.)*[A-Z]\\w+)\\b'
+    'match': '\\b(void|byte|short|char|dchar|wchar|int|long|string|wstring|dstring|float|double|bool|([a-z]\\w+\\.)*[A-Z]\\w+)\\b'
     'name': 'storage.type.d'
   'string_escaped_char':
     'patterns': [


### PR DESCRIPTION
This fixes the missing keywords in Issue #5 except for `enforce` which seems to be a function, not a keyword.